### PR TITLE
message api change

### DIFF
--- a/api/api.ml
+++ b/api/api.ml
@@ -54,7 +54,6 @@ module type STAGE_SPECIFICS =
 
     type outbound
     val stage : string
-    val next_mailbox : string option
     val outbound_dispatcher : int -> outbound -> call
 
   end
@@ -73,6 +72,8 @@ sig
   (* the stepping *)
 
   val step : (module STAGE_CONTEXT_FACTORY) -> call -> call option Lwt.t
+  val dispatch_message_automatically : uid -> string -> call option Lwt.t
+  val dispatch_message_manually : uid -> string -> string -> call option
 
   (* some static content for the client *)
 
@@ -83,6 +84,7 @@ sig
 
   val triggers : ([ `Unit | `Int | `Float | `String ] * string) list
   val mailables : string list
-  val mailing_helper : (string * string) list
+
+  val email_actions : (string * string list) list
 
 end

--- a/graph/object_message.ml
+++ b/graph/object_message.ml
@@ -38,6 +38,10 @@ type interlocutor = Stage of string | Member of uid with bin_io
 
 type strings = string list with bin_io, default_value([])
 
+type action =
+    Pending
+  | RoutedToStage of string with bin_io, default_value(Pending)
+
 let create_reference content =
   let hash = Digest.to_hex (Digest.string (Printf.sprintf "%Ld-%s" (Ys_time.now ()) content)) in
   Printf.sprintf "<%s@accret.io>" hash
@@ -60,6 +64,10 @@ type t = {
 
   reference : string ;
   references : strings ;
+
+  tags : strings ;
+
+  action : action ;
 
 } with vertex
   (

--- a/library/server/ys_executor.ml
+++ b/library/server/ys_executor.ml
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *)
 
+open Ys_types
 
 open Bin_prot.Std
 
@@ -27,4 +28,5 @@ type call =
     stage : string ;
     args : string ;
     schedule : schedule ;
+    created_on : timestamp ;
   } with bin_io


### PR DESCRIPTION
It's now possible to attach an email parser to a stage, which will attempt to guess a transition from a message. it is also possible to route the messages by hands directly from the leader interface.
