### PR TITLE
Schoolbus

### DIFF
--- a/api/api.ml
+++ b/api/api.ml
@@ -95,7 +95,7 @@ type 'output context =
     (* meta *)
 
     search_societies : query:string -> unit -> uid list Lwt.t ;
-    create_society : ?label:string -> playbook:string -> name:string -> description:string -> unit -> uid option Lwt.t ;
+    create_society : playbook:string -> name:string -> description:string -> unit -> uid option Lwt.t ;
 
   }
 
@@ -142,4 +142,12 @@ sig
   val parameters : (string * string) list
   val properties : (string * string) list
 
+end
+
+
+(* reserved stages names *)
+module Stages =
+struct
+  let init = "init__"
+  let new_member = "new_member__"
 end

--- a/api/api.ml
+++ b/api/api.ml
@@ -52,6 +52,7 @@ type 'output context =
     cancel_timers : query:string -> unit Lwt.t ;
 
     (* messaging utilities *)
+
     message_member : member:uid -> ?attachments:Object_message.attachments -> ?data:(string * string) list -> subject:string -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
     message_supervisor : subject:string -> ?attachments:Object_message.attachments -> ?data:(string * string) list -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
     reply_to : message:uid -> ?data:(string * string) list -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
@@ -90,6 +91,11 @@ type 'output context =
     request_payment : member:uid -> label:string -> evidence:Object_message.attachments -> amount:float -> on_success:(uid -> 'output) -> on_failure:(uid -> 'output) -> uid option Lwt.t ;
     payment_direct_link : payment:uid -> string Lwt.t ;
     payment_amount : payment:uid -> float Lwt.t ;
+
+    (* meta *)
+
+    search_societies : query:string -> unit -> uid list Lwt.t ;
+    create_society : ?label:string -> playbook:string -> name:string -> description:string -> unit -> uid option Lwt.t ;
 
   }
 

--- a/api/api.ml
+++ b/api/api.ml
@@ -53,7 +53,7 @@ type 'output context =
 
     (* messaging utilities *)
 
-    message_member : member:uid -> ?attachments:Object_message.attachments -> ?data:(string * string) list -> subject:string -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
+    message_member : member:uid -> ?remind_after:Calendar.Period.t -> ?attachments:Object_message.attachments -> ?data:(string * string) list -> subject:string -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
     message_supervisor : subject:string -> ?attachments:Object_message.attachments -> ?data:(string * string) list -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
     reply_to : message:uid -> ?data:(string * string) list -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
     forward_to_supervisor : message:uid -> ?data:(string * string) list -> subject:string -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
@@ -150,4 +150,5 @@ module Stages =
 struct
   let init = "init__"
   let new_member = "new_member__"
+  let remind__ = "remind__"
 end

--- a/api/api.ml
+++ b/api/api.ml
@@ -55,7 +55,7 @@ type 'output context =
 
     message_member : member:uid -> ?remind_after:Calendar.Period.t -> ?attachments:Object_message.attachments -> ?data:(string * string) list -> subject:string -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
     message_supervisor : subject:string -> ?attachments:Object_message.attachments -> ?data:(string * string) list -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
-    reply_to : message:uid -> ?data:(string * string) list -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
+    reply_to : message:uid -> ?original_stage:bool -> ?data:(string * string) list -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
     forward_to_supervisor : message:uid -> ?data:(string * string) list -> subject:string -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
 
     (* getting talent & tagging people *)

--- a/app/playbook.eliom
+++ b/app/playbook.eliom
@@ -96,6 +96,7 @@ let create_society (playbook, name, description, data) : (string * Ys_uid.uid) o
          let uid = society.Object_society.uid in
          lwt _ = $member(session.member_uid)<-societies +=! (`Society, uid) in
          lwt _ = $playbook(playbook)<-societies +=! (`Society, uid) in
+         lwt _ = Executor.stack_unit uid Api.Stages.init () in
          return (Some (shortlink, uid))
        | `Object_already_exists (_, uid) -> return (Some (shortlink, uid)))
 

--- a/app/registry.eliom
+++ b/app/registry.eliom
@@ -143,5 +143,6 @@ let start () =
   lwt _ = register (module Diy_velo_bambou) in
   lwt _ = register (module Mandarin_circle_time) in
   lwt _ = register (module Children_schoolbus) in
+  lwt _ = register (module Children_schoolbus_group) in
   (* lwt _ = register (module Bay_tours) in *)
   return_unit

--- a/app/schoolbus_blocks.eliom
+++ b/app/schoolbus_blocks.eliom
@@ -142,6 +142,21 @@ let profiles society data =
         [ pcdata "Update" ]
     in
 
+    (* groups *)
+    let groups = Raw.input ~a:[ a_input_type `Text ; a_value (String.concat ", " profile.groups) ] () in
+    let update_groups _ =
+      let groups = Ys_dom.get_value groups in
+      let groups = Regexp.split (Regexp.regexp "[\t ' ']*,[\t ' ']*") groups in
+      let profile = { profile with groups } in
+      detach_rpc %update_profile (society, Yojson_profile.to_string profile) (RList.update data)
+    in
+    let update_groups =
+      button
+        ~a:[ a_button_type `Button ;
+             a_onclick update_groups ]
+        [ pcdata "Update" ]
+    in
+
     (* the form *)
     div ~a:[ a_class [ "box" ; "schoolbus-profile" ]] [
       h3 [ pcdata profile.name ; pcdata " (" ; pcdata (string_of_int profile.uid) ; pcdata ")" ] ;
@@ -156,6 +171,10 @@ let profiles society data =
       div ~a:[ a_class [ "box-section" ; "profile-children" ]] [
         h4 [ pcdata "Children" ];
         div (List.map format_child profile.children)
+      ] ;
+      div ~a:[ a_class [ "box-section" ; "profile-children" ]] [
+        h4 [ pcdata "Groups" ];
+        groups ; update_groups ;
       ] ;
       div ~a:[ a_class [ "box-section" ; "profile-raw" ]] [
         h4 [ pcdata "Raw" ];

--- a/app/server/imap_endpoint.ml
+++ b/app/server/imap_endpoint.ml
@@ -313,6 +313,9 @@ let process_email =
                   lwt _ = $member(sender)<-messages += (`Email, message.Object_message.uid) in
                   lwt _ = $society(society)<-inbox += ((`Message Object_society.({ received_on = Ys_time.now () ; read = false })), message.Object_message.uid) in
                   Lwt_log.ign_info_f "message object created, uid is %d" message.Object_message.uid ;
+
+                  (* here we need to cancel reminding timers *)
+                  lwt _ = Executor.cancel_reminders society message.Object_message.uid in
                   (* should we add the member to the society automatically?? *)
 
                   if target_stage = "" then

--- a/app/society_leader.eliom
+++ b/app/society_leader.eliom
@@ -775,12 +775,20 @@ let dom bundle =
           [ pcdata "Remove" ]
       in
 
-      div ~a:[ a_class [ "member" ]] [
-        span ~a:[ a_class [ "member-name" ]] [ pcdata member.View_member.name ] ;
-        span ~a:[ a_class [ "member-email" ]] [ pcdata member.View_member.email ] ;
-        tag_input ;
-        tag_update ;
-        remove ;
+      div ~a:[ a_class [ "member" ; "box" ; ]] [
+        div ~a:[ a_class [ "box-section" ]] [
+          pcdata member.View_member.name
+        ] ;
+        div ~a:[ a_class [ "box-section" ]] [
+          pcdata member.View_member.email
+        ] ;
+        div ~a:[ a_class [ "box-section" ]] [
+          tag_input ;
+        ] ;
+        div ~a:[ a_class [ "box-action" ]] [
+          tag_update ;
+          remove ;
+        ] ;
       ]
     in
 
@@ -803,14 +811,22 @@ let dom bundle =
           ~a:[ a_onclick create ]
           [ pcdata "Create" ]
       in
-      div ~a:[ a_class [ "add-member" ; "left" ]] [
-        input_email ; input_tags ; create
+      div ~a:[ a_class [ "add-member" ; "box" ]] [
+        div ~a:[ a_class [ "box-section" ]] [
+          input_email
+        ] ;
+        div ~a:[ a_class [ "box-section" ]] [
+          input_tags
+        ] ;
+        div ~a:[ a_class [ "box-action" ]] [
+          create
+        ]
       ]
     in
 
     div ~a:[ a_class [ "members" ]] [
       h2 [ pcdata "Members" ] ;
-      RList.map_in_div_hd ~a:[ a_class [ "members-existing" ; "clearfix" ]] add_member format_member members ;
+      RList.map_in_div_hd ~a:[ a_class [ "members-existing" ]] add_member format_member members ;
     ]
 
   in
@@ -875,7 +891,7 @@ let dom bundle =
                a_onclick add ]
           [ pcdata "Add" ]
       in
-      div ~a:[ a_class [ "add-data" ; "box" ; "left" ]] [
+      div ~a:[ a_class [ "add-data" ; "box" ]] [
         div ~a:[ a_class [ "box-section" ]] [ input_key ] ;
         div ~a:[ a_class [ "box-section" ]] [ input_value ] ;
         div ~a:[ a_class [ "box-action" ]] [
@@ -905,10 +921,14 @@ let dom bundle =
           [ pcdata "Edit" ]
       in
 
-      div ~a:[ a_class [ "data-item" ; "left" ]] [
-        pcdata key ; pcdata " -> " ; pcdata value ;
-        edit ;
-        remove ;
+      div ~a:[ a_class [ "data-item" ; "box" ]] [
+        div ~a:[ a_class [ "box-section" ]] [
+          pcdata key ; pcdata " -> " ; pcdata value ;
+        ] ;
+        div ~a:[ a_class [ "box-action" ]] [
+          edit ;
+          remove ;
+        ]
       ]
     in
     div ~a:[ a_class [ "data" ]] [
@@ -1037,8 +1057,8 @@ let dom bundle =
   let custom_blocks =
     match bundle.view.View_society.playbook.View_playbook.name with
     | "Children schoolbus" ->
-      div ~a:[ a_class [ "custom-blocks" ]] (Schoolbus_blocks.doms bundle.view.View_society.uid data ())
-    | _ -> pcdata ""
+      Schoolbus_blocks.doms bundle.view.View_society.uid data ()
+    | _ -> []
   in
 
   (* the main dom *)
@@ -1049,36 +1069,37 @@ let dom bundle =
       div ~a:[ a_class [ "logs"; "left" ]] [  stack ; logs ] ;
       graph ;
     ] ;
-    div ~a:[ a_class [ "society-leader-lower" ]] [
+    div ~a:[ a_class [ "society-leader-lower" ]]
 
-      div ~a:[ a_class [ "mailboxes" ]] [
-        h2 [ pcdata "Mailboxes" ] ;
-        div ~a:[ a_class [ "clearfix" ]] [
-          div ~a:[ a_class [ "inbox-outer" ; "left" ]] [
-            h3 [ pcdata "Inbox" ] ;
-            inbox ;
-          ] ;
-          div ~a:[ a_class [ "outbox-outer" ; "left" ]] [
-            h3 [ pcdata "Outbox" ] ;
-            outbox
-          ] ;
-        ] ;
-      ] ;
+      (((div ~a:[ a_class [ "mailboxes" ]] [
+           h2 [ pcdata "Mailboxes" ] ;
+           div ~a:[ a_class [ "clearfix" ]] [
+             div ~a:[ a_class [ "inbox-outer" ; "left" ]] [
+               h3 [ pcdata "Inbox" ] ;
+               inbox ;
+             ] ;
+             div ~a:[ a_class [ "outbox-outer" ; "left" ]] [
+               h3 [ pcdata "Outbox" ] ;
+               outbox
+             ] ;
+           ] ;
+         ]) ;
 
-      custom_blocks ;
+         :: custom_blocks) @
 
-      div ~a:[ a_class [ "triggers" ]] [
-        h2 [ pcdata "Triggers" ] ;
-        div ~a:[ a_class [ "triggers-controls"; "clearfix" ]] triggers
-      ] ;
-      members ;
-      messenger ;
-      data_dom ;
-      parameters ;
-      name ;
-      description ;
-      supervisor ;
+         [
+           div ~a:[ a_class [ "triggers" ]] [
+             h2 [ pcdata "Triggers" ] ;
+             div ~a:[ a_class [ "triggers-controls"; "clearfix" ]] triggers
+           ] ;
+           members ;
+           messenger ;
+           data_dom ;
+           parameters ;
+           name ;
+           description ;
+           supervisor])
     ]
-  ]
+
 
 }}

--- a/app/society_leader.eliom
+++ b/app/society_leader.eliom
@@ -37,6 +37,7 @@ type bundle =
     (* society info *)
     members : (View_member.t * string list) list ;
     data : (string * string) list ;
+    societies : View_society.t list ;
   }
 
 }}
@@ -59,7 +60,7 @@ let retrieve_members uid =
 let retrieve uid =
   lwt view = View_society.to_view uid in
   lwt members = retrieve_members uid in
-  lwt data, playbook = $society(uid)->(data, playbook) in
+  lwt data, playbook, societies = $society(uid)->(data, playbook, societies) in
   Lwt_log.ign_info_f "society %d relies on playbook %d" uid playbook ;
   let automata, triggers, mailables, email_actions =
     let playbook = Registry.get playbook in
@@ -67,7 +68,7 @@ let retrieve uid =
     P.automata, P.triggers, P.mailables, P.email_actions
   in
   let triggers = List.fast_sort (fun (_, s1) (_, s2) -> String.compare s1 s2) triggers in
-
+  lwt societies = Lwt_list.map_s (fun (_, uid) -> View_society.to_view uid) societies in
   return
     {
       uid ;
@@ -78,6 +79,7 @@ let retrieve uid =
       email_actions ;
       members ;
       data ;
+      societies ;
     }
 
 let update_mode (uid, mode) =
@@ -439,6 +441,43 @@ let update_supervisor (society, email) =
          return (Some view))
 
 let update_supervisor = server_function ~name:"society-leader-update-supervisor" Json.t<int * string> update_supervisor
+
+let add_society (society, playbook, name, description) : View_society.t option Lwt.t =
+  Lwt_log.ign_info_f "creating new children society in society %d, playbook %s, name %s, description %s" society playbook name description ;
+  protected_connected
+    (fun session ->
+       match_lwt Object_playbook.Store.find_by_name playbook with
+         None ->
+         Lwt_log.ign_error_f "couldn't locate playbook %s" playbook ;
+         return_none
+       | Some playbook ->
+         (* TODO: add some safeguards here around duplicates in societies *)
+         match_lwt Ys_shortlink.create () with
+           None ->
+           Lwt_log.ign_error_f "couldn't create shortlink" ;
+           return_none
+         | Some shortlink ->
+           match_lwt Object_society.Store.create
+                       ~shortlink
+                       ~leader:session.member_uid
+                       ~name
+                       ~description
+                       ~playbook
+                       ~mode:Object_society.Public
+                       ~data:[]
+                       () with
+           | `Object_already_exists (_, uid) ->
+             (* fishy *)
+             return_none
+           | `Object_created obj ->
+             let child = obj.Object_society.uid in
+             lwt _ = $society(society)<-societies += (`Society name, child) in
+             lwt _ = $member(session.member_uid)<-societies += (`Society, child) in
+             lwt _ = Executor.stack_unit child Api.Stages.init () in
+             lwt view = View_society.to_view child in
+             return (Some view))
+
+let add_society = server_function ~name:"society-leader-add-society" Json.t<int * string * string * string> add_society
 
 }}
 
@@ -933,7 +972,7 @@ let dom bundle =
     in
     div ~a:[ a_class [ "data" ]] [
       h2 [ pcdata "Data" ] ;
-      RList.map_in_div_hd ~a:[ a_class [ "clearfix" ]] add_data format_data data
+      RList.map_in_div_hd add_data format_data data
     ]
   in
 
@@ -1061,6 +1100,51 @@ let dom bundle =
     | _ -> []
   in
 
+  (* the societies *)
+
+  let societies =
+    let societies = RList.init bundle.societies in
+    let add_society =
+      let playbook = input ~a:[ a_input_type `Text  ; a_placeholder "Playbook" ] () in
+      let name = input ~a:[ a_input_type `Text ; a_placeholder "Name" ] () in
+      let description = Raw.textarea ~a:[ a_placeholder "Description" ] (pcdata "") in
+      let create _ =
+        match Ys_dom.get_value playbook, Ys_dom.get_value name, Ys_dom.get_value_textarea description with
+        "", _, _ -> Help.warning "please specify a playbook"
+        | _, "", _ -> Help.warning "please give your society a name"
+        | _, _, "" -> Help.warning "please give your society a description"
+        | playbook_s, name_s, description_s ->
+          detach_rpc %add_society (bundle.view.uid, playbook_s, name_s, description_s)
+              (fun society ->
+                 Ys_dom.set_value playbook "" ;
+                 Ys_dom.set_value name "" ;
+                 Ys_dom.set_value_textarea description "" ;
+                 RList.add societies society)
+      in
+      let create =
+        button
+          ~a:[ a_button_type `Button ;
+               a_onclick create ]
+          [ pcdata "Create" ]
+      in
+      div ~a:[ a_class [ "add-society" ; "add-box" ]] [
+        div ~a:[ a_class [ "box-section" ]] [ playbook ] ;
+        div ~a:[ a_class [ "box-section" ]] [ name ] ;
+        div ~a:[ a_class [ "box-section" ]] [ description ] ;
+        div ~a:[ a_class [ "box-action" ]] [ create ] ;
+      ]
+    in
+    let format_society society =
+      div ~a:[ a_class [ "box" ]] [
+        pcdata society.View_society.name
+      ]
+    in
+    div ~a:[ a_class [ "societies" ]] [
+      h2 [ pcdata "Societies" ] ;
+      RList.map_in_div_hd add_society format_society societies
+    ]
+  in
+
   (* the main dom *)
 
   div ~a:[ a_class [ "society-leader" ]] [
@@ -1093,6 +1177,7 @@ let dom bundle =
              div ~a:[ a_class [ "triggers-controls"; "clearfix" ]] triggers
            ] ;
            members ;
+           societies ;
            messenger ;
            data_dom ;
            parameters ;

--- a/graph/object_playbook.ml
+++ b/graph/object_playbook.ml
@@ -75,9 +75,9 @@ type t = {
 } with vertex
   (
     {
-      aliases = [ `PlainText description ; `PlainText name ; `String hash ; `PlainText tags ] ;
+      aliases = [ `String name ; `PlainText description ; `PlainText name ; `String hash ; `PlainText tags ] ;
       required = [ owner ; name ; description ; hash ; scope ; thread ] ;
-      uniques = [ hash ] ;
+      uniques = [ hash ; name ] ;
       builders = [ (scope, (fun _ -> return Ys_scope.Private)) ] ;
     }
   )

--- a/graph/object_society.ml
+++ b/graph/object_society.ml
@@ -41,6 +41,10 @@ let data_key_to_document =
   function
     `Key label -> Some label
 
+let society_to_document =
+  function
+    `Society label -> Some label
+
 type data = (string * string) list with bin_io, default_value([])
 
 type slip =
@@ -89,10 +93,14 @@ type t = {
 
   followers : [ `Follower ] edges ;
 
+  societies : [ `Society of string ] edges ;
+
 } with vertex
   (
     {
-      aliases = [ `String shortlink ; `PlainText name ; `PlainText description ; `PlainTextEdge timers timer_to_document ; `PlainTextEdge members edge_to_document ; `PlainTextEdge data_keys data_key_to_document ] ;
+      aliases = [ `String shortlink ; `PlainText name ; `PlainText description ; `PlainTextEdge timers timer_to_document ;
+                  `PlainTextEdge societies society_to_document ;
+                  `PlainTextEdge members edge_to_document ; `PlainTextEdge data_keys data_key_to_document ] ;
       required = [ shortlink ; leader ; name ; description ; mode ; playbook ] ;
       uniques = [ shortlink ]
     }

--- a/playbooks/children_schoolbus.ml
+++ b/playbooks/children_schoolbus.ml
@@ -358,6 +358,9 @@ PLAYBOOK
 
    #import core_join_request
 
+
+(* onboarding process *)
+
    process_join_request<forward> ~> `Message of email ~> check_if_member_already_exists
 
       check_if_member_already_exists ~> `Yes ~> noop
@@ -367,7 +370,17 @@ PLAYBOOK
         store_profile_and_ask_for_missing_elements ~> `ThankMember of int ~> thank_member
         store_profile_and_ask_for_missing_elements ~> `AskMemberForMissingFields of (int * profile_fields) ~> ask_member_for_missing_fields<forward> ~> `Message of email ~> store_reply ~> `Message of email ~> ask_supervisor_to_extract_information
 
+
+(* organizing a trip *)
+
+
+
+(* some administrative work *)
+
 *group_all_members
+
+
+
 
 PROPERTIES
   - "Your duties", "None! All you have is to show up on time with your child at the pickup spot."

--- a/playbooks/children_schoolbus.ml
+++ b/playbooks/children_schoolbus.ml
@@ -53,7 +53,8 @@ let default_profile uid name email = {
   name ;
   children = [ default_child ] ;
   neighborhood = "" ;
-  schedule = ""
+  schedule = "";
+  groups = [] ;
 }
 
 (* some helpers ***************************************************************)

--- a/playbooks/children_schoolbus_group.ml
+++ b/playbooks/children_schoolbus_group.ml
@@ -103,7 +103,7 @@ let new_member__ context member =
       lwt _ =
         context.message_member
           ~member
-          ~remind_after:(Calendar.Period.lmake ~minute:15 ())
+          ~remind_after:(Calendar.Period.lmake ~hour:26 ())
           ~subject:"Preschool on wheels - quick question"
           ~content:[
             salutations ; br () ;

--- a/playbooks/children_schoolbus_group.ml
+++ b/playbooks/children_schoolbus_group.ml
@@ -1,0 +1,60 @@
+(*
+ * children_schoolbus
+ *
+ * this playbook organizes field trips for a group of children
+ *
+ *
+ * william@accret.io
+ *
+ *)
+
+
+open Lwt
+
+open Printf
+open CalendarLib
+
+open Api
+
+open Eliom_content.Html5
+open Eliom_content.Html5.D
+
+open Message_parsers
+open Toolbox
+
+open Ys_uid
+
+open Children_schoolbus_types
+
+let author = "william@accret.io"
+let name = "Children schoolbus group"
+let description = "this playbook organizes field trips for a group of children"
+let version = 0
+let tags = ""
+
+(* the stages *****************************************************************)
+
+let init__ context () =
+  context.log_info "calling init for the society" ;
+  lwt _ =
+    context.message_supervisor
+      ~subject:"Welcome"
+      ~content:[
+        pcdata "Greetings," ; br () ;
+        br () ;
+        pcdata "This society just got created." ; br () ;
+      ]
+      ()
+  in
+  return `None
+
+(* the playbook ***************************************************************)
+
+PLAYBOOK
+
+*init__
+
+
+
+PROPERTIES
+  - "Your duties", "None"

--- a/playbooks/children_schoolbus_group.ml
+++ b/playbooks/children_schoolbus_group.ml
@@ -103,14 +103,14 @@ let new_member__ context member =
       lwt _ =
         context.message_member
           ~member
-          ~remind_after:(Calendar.Period.lmake ~hour:26 ())
+          ~remind_after:(Calendar.Period.lmake ~minute:1 ())
           ~subject:"Preschool on wheels - quick question"
           ~content:[
             salutations ; br () ;
             br () ;
-            pcdata "I'm making progress on a proposal for a first trip. No date yet, but the destination would very likely be the SF Zoo." ; br () ;
+            pcdata "I'm making progress on a proposal for a first trip. No date yet, but the destination would very likely be the SF Zoo. I am working on getting firm quotes from various charter companies." ; br () ;
             br () ;
-            pcdata "I am working on getting firm quotes from various charter companies; to make things easier what would you think of doing the pickup from " ; pcdata pickup_point ; pcdata "? We could go doorstep to doorstep later." ; br () ;
+            pcdata "To make things easier for them what would you think of doing the pickup from " ; pcdata pickup_point ; pcdata " sometime around 8:30am? We could go doorstep to doorstep later." ; br () ;
           ]
           ()
       in

--- a/playbooks/children_schoolbus_group.ml
+++ b/playbooks/children_schoolbus_group.ml
@@ -32,7 +32,23 @@ let description = "this playbook organizes field trips for a group of children"
 let version = 0
 let tags = ""
 
+(* initially let's do pickups at playgrounds *)
+
+(* some keys ******************************************************************)
+
+let key_pickup_point = "pickup-point"
+
+(* some tags ******************************************************************)
+
+let tag_asked = "asked"
+let tag_confirmed = "confirmed" (* <- people that have accepted the pickup spot *)
+
+
 (* the stages *****************************************************************)
+
+(******************************************************************************)
+(* Setting up the group                                                       *)
+(******************************************************************************)
 
 let init__ context () =
   context.log_info "calling init for the society" ;
@@ -42,18 +58,74 @@ let init__ context () =
       ~content:[
         pcdata "Greetings," ; br () ;
         br () ;
-        pcdata "This society just got created." ; br () ;
+        pcdata "This society just got created. What will be the pickup point for the group?" ; br () ;
       ]
       ()
   in
   return `None
 
+let extract_pickup_point context message =
+  match_lwt context.get ~key:key_pickup_point with
+    Some _ ->
+    lwt _ =
+      context.reply_to
+        ~message
+        ~content:[ pcdata "Sorry the pickup point can only be updated from the control panel" ]
+        ()
+    in
+    return `None
+  | None ->
+    lwt content = context.get_message_content ~message in
+    lwt _ = context.set ~key:key_pickup_point ~value:content in
+    lwt _ =
+      context.reply_to
+        ~message
+        ~content:[
+          pcdata "Thanks, I registered the following pickup point:" ; br () ;
+          br () ;
+          i [ pcdata content ] ; br () ;
+          br ()
+        ]
+        ()
+    in
+    return `None
+
+let new_member__ context member =
+  context.log_info "we have a new member, %d" member ;
+  match_lwt context.get ~key:key_pickup_point with
+    None ->
+    return `None
+  | Some pickup_point ->
+    match_lwt context.check_tag_member ~member ~tag:tag_asked with
+      true -> return `None
+    | false ->
+      lwt salutations = salutations member in
+      lwt _ =
+        context.message_member
+          ~member
+          ~remind_after:(Calendar.Period.lmake ~minute:15 ())
+          ~subject:"Preschool on wheels - quick question"
+          ~content:[
+            salutations ; br () ;
+            br () ;
+            pcdata "I'm making progress on a proposal for a first trip. No date yet, but the destination would very likely be the SF Zoo." ; br () ;
+            br () ;
+            pcdata "I am working on getting firm quotes from various charter companies; to make things easier what would you think of doing the pickup from " ; pcdata pickup_point ; pcdata "? We could go doorstep to doorstep later." ; br () ;
+          ]
+          ()
+      in
+      lwt _ = context.tag_member ~member ~tags:[ tag_asked ] in
+      return `None
+
+
 (* the playbook ***************************************************************)
 
 PLAYBOOK
 
-*init__
+#import core_remind
 
+*init__<forward> ~> `Message of email ~> extract_pickup_point
+new_member__
 
 
 PROPERTIES

--- a/playbooks/children_schoolbus_types.ml
+++ b/playbooks/children_schoolbus_types.ml
@@ -30,6 +30,7 @@ type profile = {
   children : child list ;
   neighborhood : string ;
   schedule : string ;
+  groups : string list ;
 } with yojson
 
 type profile_field = Name | Children | Neighborhood | Schedule with yojson

--- a/playbooks/core_remind.ml
+++ b/playbooks/core_remind.ml
@@ -1,0 +1,43 @@
+(*
+ * core - remind
+ *
+ * william@accret.io
+ *
+ *)
+
+(* this component implements Api.Stage.remind__ *)
+
+open Lwt
+
+open Printf
+open CalendarLib
+
+open Api
+
+open Eliom_content.Html5
+open Eliom_content.Html5.D
+
+open Message_parsers
+
+let remind__ context message =
+  context.log_info "time to remind message %d" message ;
+  lwt _ =
+    context.message_supervisor
+      ~subject:"Reminder sent"
+      ~content:[
+        pcdata "I had to send a remind to message "; pcdata (string_of_int message) ; br () ;
+      ]
+      ()
+  in
+  lwt _ =
+    context.reply_to
+      ~message
+      ~content:[ pcdata "I'm almost done collecting feedback from other participants; have you seen my previous message? Thanks!" ; br () ;
+               ]
+      ()
+  in
+  return `None
+
+COMPONENT
+
+remind__

--- a/playbooks/core_remind.ml
+++ b/playbooks/core_remind.ml
@@ -32,8 +32,7 @@ let remind__ context message =
   lwt _ =
     context.reply_to
       ~message
-      ~content:[ pcdata "I'm almost done collecting feedback from other participants; have you seen my previous message? Thanks!" ; br () ;
-               ]
+      ~content:[ pcdata "Have you seen my previous message? Thanks!" ; br () ]
       ()
   in
   return `None

--- a/playbooks/core_remind.ml
+++ b/playbooks/core_remind.ml
@@ -32,6 +32,7 @@ let remind__ context message =
   lwt _ =
     context.reply_to
       ~message
+      ~original_stage:true
       ~content:[ pcdata "Have you seen my previous message? Thanks!" ; br () ]
       ()
   in

--- a/resources/sphinx.conf
+++ b/resources/sphinx.conf
@@ -138,6 +138,21 @@ index object_society_data_keys
         dict                    = keywords
 }
 
+index object_society_societies
+{
+	type			= rt
+	rt_mem_limit		= 32M
+
+	path			= db/object_society_societies
+        charset_table           = U+FF10..U+FF19->0..9, U+FF21..U+FF3A->a..z, U+FF41..U+FF5A->a..z, 0..9, A..Z->a..z, a..z
+	rt_field		= description
+        rt_attr_uint            = host
+        rt_attr_uint            = edge
+        min_prefix_len          = 0
+        min_infix_len           = 1
+        dict                    = keywords
+}
+
 index logs
 {
 	type			= rt

--- a/style/sass/_schoolbus.scss
+++ b/style/sass/_schoolbus.scss
@@ -66,3 +66,23 @@
     }
 
 }
+
+/* the blocks */
+
+.society-leader {
+
+    .schoolbus-profiles {
+        background-color: red ;
+    }
+
+    .schoolbus-profile {
+
+        margin-bottom: 10px;
+        h4 {
+            font-size: 16px;
+            line-height: 18px;
+            margin-bottom: 16px ;
+        }
+
+    }
+}

--- a/style/sass/_society_leader.scss
+++ b/style/sass/_society_leader.scss
@@ -51,18 +51,7 @@
                 padding: 10px 0;
                 font-size: 24px;
             }
-             input[type="number"], input[type="text"] {
-                    padding: 10px;
-                    font-size: 14px;
-                    color: #3d3d3d;
-                    box-sizing: border-box;
-                    width: 100px;
-                    border-radius: 5px;
-                    border: none;
-                    resize: none;
-                    margin-right: 10px;
-                    display: inline ;
-                }
+
         }
 
         .mailboxes {
@@ -111,25 +100,29 @@
                 padding-right: 10px;
                 float: left ;
             }
+            input[type="number"], input[type="text"] {
+                    padding: 10px;
+                    font-size: 14px;
+                    color: #3d3d3d;
+                    box-sizing: border-box;
+                    width: 100px;
+                    border-radius: 5px;
+                    border: none;
+                    resize: none;
+                    margin-right: 10px;
+                    display: inline ;
+            }
         }
 
         .members {
             background-color: #CECECE;
 
             .add-member {
-                float: left ;
+
             }
 
             .member {
-                float: left ;
-                margin-left: 20px;
-                .member-email {
-                    margin: 0 5px;
-                }
-                button {
-                    margin-right: 10px;
-                }
-
+                margin-top: 10px ;
             }
 
         }
@@ -147,8 +140,7 @@
         .data {
             background-color: #F9D5F9 ;
             .data-item {
-                margin-left: 20px;
-                padding: 3px 0;
+                margin-top: 10px;
             }
         }
 

--- a/style/stylesheets/style.css
+++ b/style/stylesheets/style.css
@@ -1657,7 +1657,7 @@ h2 {
 }
 /* line 78, ../sass/_schoolbus.scss */
 .society-leader .schoolbus-profile {
-  margin-bottom: 20px;
+  margin-bottom: 10px;
 }
 /* line 81, ../sass/_schoolbus.scss */
 .society-leader .schoolbus-profile h4 {

--- a/style/stylesheets/style.css
+++ b/style/stylesheets/style.css
@@ -1187,8 +1187,58 @@ h2 {
   padding: 10px 0;
   font-size: 24px;
 }
-/* line 54, ../sass/_society_leader.scss */
-.society-leader .society-leader-lower > div input[type="number"], .society-leader .society-leader-lower > div input[type="text"] {
+/* line 57, ../sass/_society_leader.scss */
+.society-leader .society-leader-lower .mailboxes {
+  background-color: green;
+}
+/* line 59, ../sass/_society_leader.scss */
+.society-leader .society-leader-lower .mailboxes .inbox-outer, .society-leader .society-leader-lower .mailboxes .outbox-outer {
+  width: 50%;
+}
+/* line 61, ../sass/_society_leader.scss */
+.society-leader .society-leader-lower .mailboxes .inbox-outer h3, .society-leader .society-leader-lower .mailboxes .outbox-outer h3 {
+  text-align: center;
+  font-size: 18px;
+  line-height: 36px;
+}
+/* line 67, ../sass/_society_leader.scss */
+.society-leader .society-leader-lower .mailboxes .inbox, .society-leader .society-leader-lower .mailboxes .outbox {
+  overflow-y: scroll;
+  max-height: 250px;
+  padding: 10px;
+}
+/* line 71, ../sass/_society_leader.scss */
+.society-leader .society-leader-lower .mailboxes .inbox .message-box, .society-leader .society-leader-lower .mailboxes .outbox .message-box {
+  border-bottom: 1px solid white;
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+}
+/* line 78, ../sass/_society_leader.scss */
+.society-leader .society-leader-lower .mailboxes .inbox {
+  background-color: black;
+  color: white;
+}
+/* line 82, ../sass/_society_leader.scss */
+.society-leader .society-leader-lower .mailboxes .inbox .tagger button {
+  margin-right: 10px;
+}
+/* line 89, ../sass/_society_leader.scss */
+.society-leader .society-leader-lower .mailboxes .outbox {
+  background-color: pink;
+}
+/* line 95, ../sass/_society_leader.scss */
+.society-leader .society-leader-lower .triggers {
+  background-color: orange;
+}
+/* line 97, ../sass/_society_leader.scss */
+.society-leader .society-leader-lower .triggers .trigger {
+  width: 550px;
+  padding-bottom: 10px;
+  padding-right: 10px;
+  float: left;
+}
+/* line 103, ../sass/_society_leader.scss */
+.society-leader .society-leader-lower .triggers input[type="number"], .society-leader .society-leader-lower .triggers input[type="text"] {
   padding: 10px;
   font-size: 14px;
   color: #3d3d3d;
@@ -1200,99 +1250,35 @@ h2 {
   margin-right: 10px;
   display: inline;
 }
-/* line 68, ../sass/_society_leader.scss */
-.society-leader .society-leader-lower .mailboxes {
-  background-color: green;
-}
-/* line 70, ../sass/_society_leader.scss */
-.society-leader .society-leader-lower .mailboxes .inbox-outer, .society-leader .society-leader-lower .mailboxes .outbox-outer {
-  width: 50%;
-}
-/* line 72, ../sass/_society_leader.scss */
-.society-leader .society-leader-lower .mailboxes .inbox-outer h3, .society-leader .society-leader-lower .mailboxes .outbox-outer h3 {
-  text-align: center;
-  font-size: 18px;
-  line-height: 36px;
-}
-/* line 78, ../sass/_society_leader.scss */
-.society-leader .society-leader-lower .mailboxes .inbox, .society-leader .society-leader-lower .mailboxes .outbox {
-  overflow-y: scroll;
-  max-height: 250px;
-  padding: 10px;
-}
-/* line 82, ../sass/_society_leader.scss */
-.society-leader .society-leader-lower .mailboxes .inbox .message-box, .society-leader .society-leader-lower .mailboxes .outbox .message-box {
-  border-bottom: 1px solid white;
-  margin-bottom: 10px;
-  padding-bottom: 10px;
-}
-/* line 89, ../sass/_society_leader.scss */
-.society-leader .society-leader-lower .mailboxes .inbox {
-  background-color: black;
-  color: white;
-}
-/* line 93, ../sass/_society_leader.scss */
-.society-leader .society-leader-lower .mailboxes .inbox .tagger button {
-  margin-right: 10px;
-}
-/* line 100, ../sass/_society_leader.scss */
-.society-leader .society-leader-lower .mailboxes .outbox {
-  background-color: pink;
-}
-/* line 106, ../sass/_society_leader.scss */
-.society-leader .society-leader-lower .triggers {
-  background-color: orange;
-}
-/* line 108, ../sass/_society_leader.scss */
-.society-leader .society-leader-lower .triggers .trigger {
-  width: 550px;
-  padding-bottom: 10px;
-  padding-right: 10px;
-  float: left;
-}
-/* line 116, ../sass/_society_leader.scss */
+/* line 117, ../sass/_society_leader.scss */
 .society-leader .society-leader-lower .members {
   background-color: #CECECE;
 }
-/* line 119, ../sass/_society_leader.scss */
-.society-leader .society-leader-lower .members .add-member {
-  float: left;
-}
-/* line 123, ../sass/_society_leader.scss */
+/* line 124, ../sass/_society_leader.scss */
 .society-leader .society-leader-lower .members .member {
-  float: left;
-  margin-left: 20px;
+  margin-top: 10px;
 }
-/* line 126, ../sass/_society_leader.scss */
-.society-leader .society-leader-lower .members .member .member-email {
-  margin: 0 5px;
-}
-/* line 129, ../sass/_society_leader.scss */
-.society-leader .society-leader-lower .members .member button {
-  margin-right: 10px;
-}
-/* line 137, ../sass/_society_leader.scss */
+/* line 130, ../sass/_society_leader.scss */
 .society-leader .society-leader-lower .messenger {
   background-color: yellow;
 }
-/* line 139, ../sass/_society_leader.scss */
+/* line 132, ../sass/_society_leader.scss */
 .society-leader .society-leader-lower .messenger button {
   margin-left: 10px;
 }
-/* line 142, ../sass/_society_leader.scss */
+/* line 135, ../sass/_society_leader.scss */
 .society-leader .society-leader-lower .messenger .messenger-controls {
   margin-top: 10px;
 }
-/* line 147, ../sass/_society_leader.scss */
+/* line 140, ../sass/_society_leader.scss */
 .society-leader .society-leader-lower .data {
   background-color: #f9d5f9;
 }
-/* line 149, ../sass/_society_leader.scss */
+/* line 142, ../sass/_society_leader.scss */
 .society-leader .society-leader-lower .data .data-item {
-  margin-left: 20px;
-  padding: 3px 0;
+  margin-top: 10px;
 }
-/* line 156, ../sass/_society_leader.scss */
+/* line 148, ../sass/_society_leader.scss */
 .society-leader .society-leader-lower .supervisor input[type="text"] {
   width: 100%;
 }
@@ -1662,4 +1648,20 @@ h2 {
   font-weight: bold;
   font-size: 16px;
   margin-bottom: 10px;
+}
+
+/* the blocks */
+/* line 74, ../sass/_schoolbus.scss */
+.society-leader .schoolbus-profiles {
+  background-color: red;
+}
+/* line 78, ../sass/_schoolbus.scss */
+.society-leader .schoolbus-profile {
+  margin-bottom: 20px;
+}
+/* line 81, ../sass/_schoolbus.scss */
+.society-leader .schoolbus-profile h4 {
+  font-size: 16px;
+  line-height: 18px;
+  margin-bottom: 16px;
 }


### PR DESCRIPTION
- core: 
  - adding ~remind_after to Api.message_member
  - introducing reserved stage names (defined in Api.Stages) and implementing remind__ in a new component, core_remind
  - adding children societies to societies
  - extended the leader dashboard to create children societies / refactoring / css
  - extending the API to allow for programmatic creation of societies
- schoolbus
  - introducing a children schoolbus playbook
