### PR TITLE
Reworking the messaging API

### DIFF
--- a/_tags
+++ b/_tags
@@ -30,7 +30,6 @@
 <app/server/ys_config.ml>: pkg_tyxml.parser
 <app/server/ys_persistency.ml>: pkg_leveldb
 <app/server/ys_aliases.ml>: pkg_aliases.patriciatree, pkg_mysql
-<app/server/ys_googlemaps.ml>: pkg_deriving.syntax.tc,pkg_deriving-yojson.syntax
 
 <app/server/engine.ml>: pkg_mysql
 <app/server/logs.ml>: pkg_mysql
@@ -72,3 +71,4 @@
 ################################################################################
 
 <library/syntax/*>: pkg_camlp4.lib,pkg_camlp4.quotations.r,pkg_camlp4.metagenerator,pkg_camlp4.extend,syntax_camlp4o,pkg_type_conv,pkg_ocamlgraph,pkg_deriving.tc
+<app/*/ys_googlemaps*.ml>: pkg_deriving.syntax.tc,pkg_deriving-yojson.syntax

--- a/api/api.ml
+++ b/api/api.ml
@@ -58,6 +58,9 @@ type 'output context =
     reply_to : message:uid -> ?original_stage:bool -> ?data:(string * string) list -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
     forward_to_supervisor : message:uid -> ?data:(string * string) list -> subject:string -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
 
+    (* not sure about the typing of content here; might be easier to forget HTML and go for raw text? *)
+    message_society : society:uid -> ?remind_after:Calendar.Period.t -> stage:string -> subject:string -> content:string -> unit -> uid option Lwt.t ;
+
     (* getting talent & tagging people *)
 
     search_members : ?max:int -> query:string -> unit -> uid list Lwt.t ;

--- a/api/api.ml
+++ b/api/api.ml
@@ -53,13 +53,46 @@ type 'output context =
 
     (* messaging utilities *)
 
-    message_member : member:uid -> ?remind_after:Calendar.Period.t -> ?attachments:Object_message.attachments -> ?data:(string * string) list -> subject:string -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
-    message_supervisor : subject:string -> ?attachments:Object_message.attachments -> ?data:(string * string) list -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
-    reply_to : message:uid -> ?original_stage:bool -> ?data:(string * string) list -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
-    forward_to_supervisor : message:uid -> ?data:(string * string) list -> subject:string -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t ;
+    message_member : member:uid ->
+      ?remind_after:Calendar.Period.t ->
+      ?attachments:Object_message.attachments ->
+      ?data:(string * string) list ->
+      subject:string ->
+      content:Html5_types.div_content_fun elt list ->
+      unit ->
+      uid option Lwt.t ;
+
+    message_supervisor : ?attachments:Object_message.attachments ->
+      ?data:(string * string) list ->
+      subject:string ->
+      content:Html5_types.div_content_fun elt list ->
+      unit ->
+      uid option Lwt.t ;
+
+    message_society : society:uid ->
+      ?remind_after:Calendar.Period.t ->
+      ?data:(string * string) list ->
+      stage:string ->
+      subject:string ->
+      content:string ->
+      unit ->
+      uid option Lwt.t ;
+
+    reply_to : message:uid ->
+      ?preserve_origin:bool ->
+      ?data:(string * string) list ->
+      content:Html5_types.div_content_fun elt list ->
+      unit ->
+      uid option Lwt.t ;
+
+    forward_to_supervisor : message:uid ->
+      ?data:(string * string) list ->
+      subject:string ->
+      content:Html5_types.div_content_fun elt list ->
+      unit ->
+      uid option Lwt.t ;
 
     (* not sure about the typing of content here; might be easier to forget HTML and go for raw text? *)
-    message_society : society:uid -> ?remind_after:Calendar.Period.t -> stage:string -> subject:string -> content:string -> unit -> uid option Lwt.t ;
 
     (* getting talent & tagging people *)
 
@@ -80,6 +113,8 @@ type 'output context =
     get_message_content : message:uid -> string Lwt.t ;
     get_message_raw_content : message:uid -> string Lwt.t ;
     get_message_sender : message:uid -> uid Lwt.t ;
+    (* ^^ this call will be deprecated soon as it assumes that the message has been
+       send by a user *)
     get_original_message : message:uid -> uid Lwt.t ;
     get_message_data : message:uid -> key:string -> string option Lwt.t ;
 

--- a/app/registry.eliom
+++ b/app/registry.eliom
@@ -144,5 +144,6 @@ let start () =
   lwt _ = register (module Mandarin_circle_time) in
   lwt _ = register (module Children_schoolbus) in
   lwt _ = register (module Children_schoolbus_group) in
+  lwt _ = register (module Children_schoolbus_transportation) in
   (* lwt _ = register (module Bay_tours) in *)
   return_unit

--- a/app/registry.eliom
+++ b/app/registry.eliom
@@ -145,5 +145,6 @@ let start () =
   lwt _ = register (module Children_schoolbus) in
   lwt _ = register (module Children_schoolbus_group) in
   lwt _ = register (module Children_schoolbus_transportation) in
+  lwt _ = register (module Children_schoolbus_planner) in
   (* lwt _ = register (module Bay_tours) in *)
   return_unit

--- a/app/server/executor.ml
+++ b/app/server/executor.ml
@@ -36,21 +36,7 @@ module SetString = Set.Make(String)
 
 let int_args i = Yojson_int.to_string i
 
-(* the context factory -- there is a little bit a first class module magic
-   so that pa_playbook can craft a context specific to each module ************)
-
-module type MODE_SPECIFICS = functor (Stage_specifics : STAGE_SPECIFICS) ->
-sig
-
-  val log_info : ('a, unit, string, unit) Pervasives.format4 -> 'a
-  val log_warning : ?exn:exn -> ('a, unit, string, unit) Pervasives.format4 -> 'a
-  val log_error :  ?exn:exn -> ('a, unit, string, unit) Pervasives.format4 -> 'a
-
-  val message_member : member:uid -> ?attachments:Object_message.attachments -> ?data:(string * string) list -> subject:string -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t
-  val reply_to : message:uid -> ?original_stage:bool -> ?data:(string * string) list -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t
-  val forward_to_supervisor : message:uid -> ?data:(string * string) list -> subject:string -> content:Html5_types.div_content_fun elt list -> unit -> uid option Lwt.t
-
-end
+(* the context factory ********************************************************)
 
 let reminder_label uid = sprintf "remindemail%d" uid
 
@@ -74,9 +60,7 @@ let check_missing_parameters society =
 
 let format_interlocutor =
   function
-    Object_message.Stage stage ->
-    return (Printf.sprintf "Stage %s" stage)
-  | Object_message.Member member ->
+    Object_message.Member member ->
     lwt name, preferred_email = $member(member)->(name, preferred_email) in
     return (Printf.sprintf "Member %s <%s>" name preferred_email)
   | Object_message.CatchAll ->
@@ -85,12 +69,14 @@ let format_interlocutor =
     lwt shortlink = $society(society)->shortlink in
     return (Printf.sprintf "Society %d <%s+%s@accret.io>" society shortlink stage)
 
-let context_factory mode society =
+let context_factory society =
 
   lwt society_name, society_description, society_shortlink, society_supervisor = $society(society)->(name, description, shortlink, leader) in
   let direct_link = (Ys_config.get_string "url-prefix")^"/society/"^society_shortlink in
 
-  let mode_specifics =
+  let this_society = society in
+
+  (* let mode_specifics =
     match mode with
     | `Sandbox ->
       let module Mode_Specifics (Stage_Specifics: STAGE_SPECIFICS) =
@@ -127,7 +113,6 @@ let context_factory mode society =
           let origin = Object_message.Stage Stage_Specifics.stage in
           lwt uid =
             match_lwt Object_message.Store.create
-                        ~society
                         ~origin
                         ~content
                         ~subject
@@ -223,24 +208,21 @@ let context_factory mode society =
                Lwt_log.ign_error_f ?exn "society %d: %s" society message ;
                ignore_result (Logs.insert source timestamp message)) fmt
 
-        let send_message ?(stage=None) ?(in_reply_to=None) ?(reference=None) ?(attachments=[]) ?(data=[]) member subject content =
+        let send_message ?(in_reply_to=None) ?(reference=None) ?(attachments=[]) ?(data=[]) origin destination subject content =
             let flat_content = ref "" in
             Printer.print_list (fun s -> flat_content := !flat_content ^ s) content ;
 
-            let stage =
-              match stage with
-                None -> Stage_Specifics.stage
-              | Some stage -> stage
-            in
-            let origin = Object_message.Stage stage in
+            let origin =
+              match origin with
+                Some origin -> origin
+              | None -> Object_message.Society (society, stage) in
 
             lwt uid =
               match_lwt Object_message.Store.create
-                          ~society
                           ~origin
                           ~content:!flat_content
                           ~subject
-                          ~destination:(Object_message.Member member)
+                          ~destination
                           ~reference:(Object_message.create_reference subject)
                           ~references:(match reference with Some reference -> [ reference ] | None -> [])
                           () with
@@ -257,22 +239,31 @@ let context_factory mode society =
                     data)
             in
             lwt _ = $society(society)<-outbox += (`Message (Object_society.({ received_on = Ys_time.now (); read = true })), uid) in
-            lwt _ = Notify.api_send_message ?in_reply_to reference ~attachments society stage subject member content in
-            return (Some uid)
+
+            (* little bit hackish here *)
+            match destination with
+              Object_message.CatchAll -> return_none
+            | Object_message.Member uid ->
+              lwt _ = Notify.send_message message in
+              return (Some uid)
+            | Object_message.Society (society', stage) ->
+              lwt _ = dispatch_message_society society' stage message in
+              return (Some uid)
+
 
         let message_member ~member ?(attachments=[]) ?(data=[]) ~subject ~content () =
           send_message ~data ~attachments member subject content
 
-        let reply_to ~message ?(original_stage=false) ?(data=[]) ~content () =
+        let reply_to ~message ?remind_after ?(preserve_sender=false) ?(data=[]) ~content () =
           lwt subject = $message(message)->subject in
-          lwt stage =
-            match original_stage with
-              false -> return_none
-            | true ->
-              match_lwt $message(message)->origin with
-                Object_message.Stage stage -> return (Some stage)
-              | _ -> return_none
+          let subject = "Re: " ^ subject in
+
+          lwt origin =
+            match preserver_sender with
+              false -> return (Object_message.Society (society, stage))
+            | true -> $message(message)->origin
           in
+
           match_lwt $message(message)->(origin, destination) with
           | Object_message.Member member, _
           | _, Object_message.Member member ->
@@ -311,7 +302,6 @@ let context_factory mode society =
           Printer.print_list (fun s -> flat_content := !flat_content ^ s) content ;
           lwt uid =
             match_lwt Object_message.Store.create
-                        ~society
                           ~origin:(Object_message.Stage stage)
                           ~content:!flat_content
                           ~subject
@@ -354,13 +344,40 @@ let context_factory mode society =
 
   let module Mode_Specifics = (val mode_specifics : MODE_SPECIFICS) in
 
-  let module Factory (Mode_Specifics: MODE_SPECIFICS) (Stage_Specifics : STAGE_SPECIFICS) =
+  *)
+
+  let module Factory (Stage_Specifics : STAGE_SPECIFICS) =
   struct
 
     include Stage_Specifics
-    include Mode_Specifics(Stage_Specifics)
 
-    (* getting talent & tagging people *)
+    (* logging utilities *)
+
+    let log_info = fun fmt ->
+      let source = sprintf "context-info-%d" society in
+      let timestamp = Ys_time.now () in
+      Printf.ksprintf
+            (fun message ->
+            Lwt_log.ign_info_f "society %d: %s" society message ;
+            ignore_result (Logs.insert source timestamp message)) fmt
+
+    let log_warning = fun ?exn fmt ->
+      let source = sprintf "context-warning-%d" society in
+      let timestamp = Ys_time.now () in
+      Printf.ksprintf
+        (fun message ->
+           Lwt_log.ign_warning_f ?exn "society %d: %s" society message ;
+           ignore_result (Logs.insert source timestamp message)) fmt
+
+    let log_error = fun ?exn fmt ->
+      let source = sprintf "context-error-%d" society in
+      let timestamp = Ys_time.now () in
+      Printf.ksprintf
+        (fun message ->
+           Lwt_log.ign_error_f ?exn "society %d: %s" society message ;
+           ignore_result (Logs.insert source timestamp message)) fmt
+
+    (* getting talent & tagging people **************************************************)
 
     let search_members ?max ~query () =
       Object_society.Store.search_members society query
@@ -431,9 +448,9 @@ let context_factory mode society =
     let get_message_raw_content ~message =
       $message(message)->raw
 
+    (* this will be deprecated soon *)
     let get_message_sender ~message =
       match_lwt $message(message)->origin with
-      | Object_message.Stage _ -> failwith "this email was sent by a stage"
       | Object_message.CatchAll -> failwith "this email was sent from the catchall"
       | Object_message.Society _ -> failwith "this email was sent from a society"
       | Object_message.Member member -> return member
@@ -484,6 +501,7 @@ let context_factory mode society =
       lwt _ = $society(society)<-tombstones %% (fun tombstones -> calls @ tombstones) in
       return_unit
 
+    (* probably not correct anymore *)
     let rec get_original_message ~message =
       let rec aux message =
         match_lwt $message(message)->references with
@@ -495,8 +513,7 @@ let context_factory mode society =
                | None -> return acc
                | Some message ->
                  match_lwt $message(message)->origin with
-                   Object_message.Stage _ -> aux message
-                 | Object_message.CatchAll -> aux message
+                   Object_message.CatchAll -> aux message
                  | Object_message.Society _ -> aux message
                  | Object_message.Member _ ->
                    match_lwt aux message with
@@ -548,17 +565,181 @@ let context_factory mode society =
      lwt members = $society(society)->members in
      return (Ys_uid.Edges.mem member members)
 
-   (* message primitives *)
+    (* some mailing helpers ***************************************************)
 
-   let message_supervisor ~subject ?(attachments=[]) ?(data=[]) ~content () =
-     lwt leader = $society(society)->leader in
-     let content =
-       content @ [ br () ; pcdata "The society dashboard is accessible here: " ;
-                   Raw.a ~a:[ a_href (uri_of_string (fun () -> direct_link)) ] [ pcdata direct_link ] ; br () ]
-     in
-     message_member ~member:leader ~attachments ~subject:(Printf.sprintf "[Accretio] [%s] %s" society_name subject) ~data ~content ()
+    let setup_reminder remind_after uid =
+      match remind_after with
+        None -> return_unit
+      | Some remind_after ->
+        let label = reminder_label uid in
+        (* a bit hackish here *)
+        let y, m, d, s = Calendar.Period.ymds remind_after in
+        let duration = s + (d * 24 * 3600) in
+        let call = {
+          stage = Api.Stages.remind__ ;
+          args = Deriving_Yojson.Yojson_int.to_string uid ;
+          schedule = Delayed duration ;
+          created_on = Ys_time.now ()
+        } in
+        lwt _ = $society(society)<-sidecar %% (fun s -> (society, call) :: s) in
+        log_info "setting timer %s" label ;
+        match_lwt Object_timer.Store.create
+                    ~society
+                    ~call
+                    () with
+        | `Object_already_created _ -> return_unit
+        | `Object_created timer ->
+          lwt _ = $society(society)<-timers += (`Label label, timer.Object_timer.uid) in
+          return_unit
 
-    (* payments *)
+    let dispatch_message_society society stage message =
+      try
+        lwt playbook = $society(society)->playbook in
+        let module Playbook = (val (Registry.get playbook) : Api.PLAYBOOK) in
+        match List.mem stage Playbook.mailables with
+          false ->
+          log_error "message %d was intended for stage %s in society %d, but this stage isn't mailable" message stage society ;
+          List.iter (fun stage ->
+              Lwt_log.ign_info_f "mailable stage in society %d: %s" society stage)
+            Playbook.mailables ;
+          return_none
+        | true ->
+          lwt _ = $society(society)<-inbox += (`Message (Object_society.({ received_on = Ys_time.now (); read = false })), message) in
+
+          (* we are making the assumption that stage is indeed expecting an int
+             on the other side, we'll have ACL's to filter out unintended messages *)
+
+          match_lwt Playbook.dispatch_message_automatically message stage with
+          | None -> return (Some message)
+          | Some call ->
+            lwt _ =
+              $society(this_society)<-sidecar %% (fun stack -> (society, call) :: stack)
+            in
+            return (Some message)
+      with Not_found ->
+        Lwt_log.ign_info_f "couldn't find playbook for society %d, can't send message %d" society message ;
+        return_none
+
+    (* message primitives ****************************************************************)
+
+    let send_message ?remind_after ?(references=[]) ?(data=[]) origin destination subject content =
+      lwt uid =
+        match_lwt Object_message.Store.create
+                    ~origin
+                    ~content
+                    ~subject
+                    ~destination
+                    ~reference:(Object_message.create_reference subject)
+                    ~references
+                    () with
+        | `Object_already_exists (_, uid) -> return uid
+        | `Object_created message -> return message.Object_message.uid
+      in
+      lwt reference = $message(uid)->reference in
+      lwt _ =
+        $society(society)<-data %% (fun store ->
+            List.fold_left
+              (fun acc (key, value) ->
+                 (reference^"-"^key, value) :: acc)
+              store
+              data)
+      in
+
+      lwt _ = $society(society)<-outbox += (`Message (Object_society.({ received_on = Ys_time.now (); read = false })), uid) in
+      lwt _ = setup_reminder remind_after uid in
+
+      match_lwt $society(society)->mode with
+        Object_society.Sandbox -> return (Some uid)
+      | Object_society.Public
+      | Object_society.Private ->
+        match destination with
+          Object_message.CatchAll -> return_none
+        | Object_message.Member _ ->
+          lwt _ = Notify.send_message uid in
+          return (Some uid)
+        | Object_message.Society (society, stage) ->
+          dispatch_message_society society stage uid
+
+   let message_member ~member ?remind_after ?attachments ?data ~subject ~content () =
+     let flat_content = ref "" in
+     Printer.print_list (fun s -> flat_content := !flat_content ^ s) content ;
+     let origin = Object_message.Society (society, stage) in
+     let destination = Object_message.Member member in
+     send_message ?remind_after ?data origin destination subject !flat_content
+
+    let message_supervisor ?attachments ?data ~subject ~content () =
+      lwt leader = $society(society)->leader in
+      let content =
+        content @ [ br () ; pcdata "The society dashboard is accessible here: " ;
+                    Raw.a ~a:[ a_href (uri_of_string (fun () -> direct_link)) ] [ pcdata direct_link ] ; br () ]
+      in
+      message_member ~member:leader ?attachments ?data ~subject:(Printf.sprintf "[Accretio] [%s] %s" society_name subject) ~content ()
+
+    let message_society ~society ?remind_after ?data ~stage ~subject ~content () =
+      let origin = Object_message.Society (this_society, Stage_Specifics.stage) in
+      let destination = Object_message.Society (society, stage) in
+      send_message ?remind_after ?data origin destination subject content
+
+    let reply_to ~message ?(preserve_origin=false) ?data ~content () =
+      let flat_content = ref "" in
+      Printer.print_list (fun s -> flat_content := !flat_content ^ s) content ;
+
+      lwt subject = $message(message)->subject in
+      let subject = "Re: " ^ subject in
+
+      lwt reference = $message(message)->reference in
+
+      lwt origin =
+        match preserve_origin with
+          false -> return (Object_message.Society (society, stage))
+        | true ->
+          match_lwt $message(message)->origin with
+          | Object_message.Society (s', stage) as origin when s' = society -> return origin
+          | _ ->
+            Lwt_log.ign_info_f "couldn't preserve origin when replying to message %d in society %d" message society ;
+            return (Object_message.Society (society, stage))
+      in
+
+      lwt destination =
+        (* that's more or less what gmaps does when you hit "reply" *)
+        match preserve_origin with
+          false ->
+          (match_lwt $message(message)->origin with
+           | Object_message.Society (society', stage') when society' = society && stage' = stage ->
+             $message(message)->destination
+           | _ as origin -> return origin)
+        | true ->
+          (* here we can assume that we are trying to connect with the same destination,
+             as otherwise it would mean that we are spoofing something *)
+          $message(message)->destination
+      in
+
+      send_message ?data ~references:[ reference ] origin destination subject !flat_content
+
+    let forward_to_supervisor ~message ?(data=[]) ~subject ~content () =
+      lwt leader = $society(society)->leader in
+      let subject = Printf.sprintf "[Accretio] [%s] %s" society_name subject in
+
+      lwt original_origin, original_destination = $message(message)->(origin, destination) in
+      lwt origin = format_interlocutor original_origin in
+      lwt destination = format_interlocutor original_destination in
+
+      lwt reference, original_content, attachments = $message(message)->(reference, raw, attachments) in
+
+      let content =
+        content @ [ br () ;
+                    br () ;
+                    pcdata "-----" ; br () ;
+                    br () ;
+                    pcdata "From: " ; pcdata origin ; br () ;
+                    pcdata "To: " ; pcdata destination ; br () ;
+                    br () ;
+                    Unsafe.data original_content
+                  ]
+      in
+      message_member ~member:leader ~attachments ~subject ~content ()
+
+    (* payments ***************************************************************)
 
     let request_payment ~member ~label ~evidence ~amount ~on_success ~on_failure =
       log_info "requesting payment to member %d" member ;
@@ -596,7 +777,7 @@ let context_factory mode society =
     let payment_amount ~payment =
       $payment(payment)->amount
 
-    (* meta *)
+    (* meta *******************************************************************)
 
     let search_societies ~query () =
       Object_society.Store.search_societies society query
@@ -628,47 +809,15 @@ let context_factory mode society =
              lwt _ = $society(society)<-societies += (`Society name, obj.Object_society.uid) in
              return (Some obj.Object_society.uid)
 
-(* shadow message_member with timeouts *)
 
-    let setup_reminder remind_after uid =
-      let label = reminder_label uid in
-      (* a bit hackish here *)
-      let y, m, d, s = Calendar.Period.ymds remind_after in
-      let duration = s + (d * 24 * 3600) in
-      let call = {
-        stage = Api.Stages.remind__ ;
-        args = Deriving_Yojson.Yojson_int.to_string uid ;
-        schedule = Delayed duration ;
-        created_on = Ys_time.now ()
-      } in
-      lwt _ = $society(society)<-sidecar %% (fun s -> (society, call) :: s) in
-      log_info "setting timer %s" label ;
-      match_lwt Object_timer.Store.create
-                  ~society
-                  ~call
-                  () with
-      | `Object_already_created _ -> return_unit
-      | `Object_created timer ->
-        lwt _ = $society(society)<-timers += (`Label label, timer.Object_timer.uid) in
-        return_unit
-
-   let message_member ~member ?remind_after ?(attachments=[]) ?(data=[]) ~subject ~content () =
-     match_lwt message_member ~member ~attachments ~data ~subject ~content () with
-       None -> return_none
-     | Some uid ->
-       match remind_after with
-         None -> return (Some uid)
-       | Some remind_after ->
-         lwt _ = setup_reminder remind_after uid in
-         return (Some uid)
 
     (* atm, sending a message to a society bypasses the regular email protocol - to be changed later *)
+(*
     let society2 = society
     let message_society ~society ?remind_after ~stage ~subject ~content () =
-      let origin = Object_message.Stage Stage_Specifics.stage in
+      let origin = Object_message.Society (society2, Stage_Specifics.stage) in
       lwt uid =
         match_lwt Object_message.Store.create
-                    ~society
                     ~origin
                     ~content
                     ~subject
@@ -696,6 +845,7 @@ let context_factory mode society =
       | Some remind_after ->
         lwt _ = setup_reminder remind_after uid in
         return (Some uid)
+*)
 
     (* now we finally have the context that we'll feed to the specific stage *)
 
@@ -754,12 +904,7 @@ let context_factory mode society =
     }
 
   end in
-  let module FactoryWithMode = Factory(Mode_Specifics) in
-  return (module FactoryWithMode: STAGE_CONTEXT_FACTORY)
-
-let context_factory_sandbox = context_factory `Sandbox
-let context_factory_production = context_factory `Production
-
+  return (module Factory: STAGE_CONTEXT_FACTORY)
 
 (* the step-by-step execution *)
 
@@ -777,15 +922,7 @@ let step society =
 
     lwt playbook, mode = $society(society)->(playbook, mode) in
 
-    lwt context_factory =
-      match mode with
-      | Object_society.Sandbox ->
-        Lwt_log.ign_info_f "society %d is running in mode sandbox" society ;
-        context_factory_sandbox society
-      | _ ->
-        Lwt_log.ign_info_f "society %d is running in mode production" society ;
-        context_factory_production society
-    in
+    lwt context_factory = context_factory society in
 
     let playbook = Registry.get playbook in (* here we want to revisit how we load playbooks, but fine *)
     let module Playbook = (val playbook : Api.PLAYBOOK) in

--- a/app/server/imap_endpoint.ml
+++ b/app/server/imap_endpoint.ml
@@ -284,7 +284,7 @@ let process_email =
                   if target_stage = "" then
                     Object_message.CatchAll
                   else
-                    Object_message.(Stage target_stage) in
+                    Object_message.Society (society, target_stage) in
 
                 let attachments =
                   List.map
@@ -295,13 +295,12 @@ let process_email =
 
                 match_lwt
                   Object_message.Store.create
-                    ~society
                     ~subject
                     ~transport
                     ~content
                     ~origin
                     ~destination
-                    ~reference:(Object_message.create_reference content)
+                    ~reference:message_id
                     ~references
                     ~attachments
                     ~raw

--- a/app/server/migration.ml
+++ b/app/server/migration.ml
@@ -224,37 +224,6 @@ let move_to_ocsipersist () =
       Object_timer.Store.db, "object_timer" ;
     ]
 
-let relink_messages_from_followers () =
-  Lwt_log.ign_info_f "relinking messages from followers" ;
-  lwt _ =
-    Object_society.Store.fold_flat_lwt
-      (fun _ uid ->
-         lwt followers = $society(uid)->followers in
-         lwt _ =
-           Lwt_list.iter_s
-             (fun (_, follower) ->
-                lwt messages = $member(follower)->messages in
-                lwt messages =
-                  Lwt_list.filter_s
-                    (fun (`Email, uid) ->
-                      match_lwt $message(uid)->destination with
-                         | Object_message.Stage stage when stage = "process_join_request" -> return_true
-                         | _ -> return_false)
-                 messages
-               in
-               lwt _=
-                 Lwt_list.iter_s
-                   (fun (`Email, message) -> lwt _ = $society(uid)<-inbox += ((`Message Object_society.({ received_on = Ys_time.now () ; read = false })), message) in return_unit)
-                   messages
-               in
-               return_unit) followers in
-               return (Some ()))
-      ()
-      None
-      (-1)
-  in
-  return_unit
-
 let run () =
   try_lwt
     (* lwt _ = relink_messages_from_followers  () in *)

--- a/app/society_leader.eliom
+++ b/app/society_leader.eliom
@@ -200,7 +200,10 @@ let add_members (uid, emails, tags) =
               in
               Lwt_log.ign_info_f "adding member %d via email %s in society %d" member email uid ;
               let tags = "active" :: tags in
+
               lwt _ = $society(uid)<-members +=! (`Member tags, member) in
+              (* we need to call add_member here *)
+              lwt _ = Executor.stack_int uid Api.Stages.new_member member in
               return_unit)
            emails in
        lwt members = retrieve_members uid in

--- a/app/society_leader.eliom
+++ b/app/society_leader.eliom
@@ -571,6 +571,7 @@ let dom bundle =
       let tagger =
         match message.View_message.destination with
           View_message.Member _
+        | View_message.Society _
         | View_message.CatchAll -> pcdata ""
         | View_message.Stage stage ->
           try

--- a/app/society_public.eliom
+++ b/app/society_public.eliom
@@ -52,13 +52,12 @@ let request_to_join_ (society, email, content) =
   in
   lwt _ = $society(society)<-followers += (`Follower, sender) in
   match_lwt Object_message.Store.create
-              ~society
               ~subject:"Request to join"
               ~transport:Object_message.NoTransport
               ~content
               ~raw:content
               ~origin:(Object_message.Member sender)
-              ~destination:(Object_message.Stage stage)
+              ~destination:(Object_message.Society (society, stage))
               ~reference:(Object_message.create_reference content)
               () with
   | `Object_already_exists _ -> return_none

--- a/app/view_message.eliom
+++ b/app/view_message.eliom
@@ -45,12 +45,12 @@ type t =
 {server{
 
 let to_interlocutor = function
-  Object_message.Stage stage -> return (Stage stage)
-| Object_message.Member uid ->
-  lwt view = View_member.to_view uid in return (Member view)
-| Object_message.CatchAll -> return CatchAll
-| Object_message.Society (uid, stage) ->
-  lwt view = View_society.to_view uid in return (Society (view, stage))
+    Object_message.Stage stage -> return (Stage stage)
+  | Object_message.Member uid ->
+    lwt view = View_member.to_view uid in return (Member view)
+  | Object_message.CatchAll -> return CatchAll
+  | Object_message.Society (uid, stage) ->
+    lwt view = View_society.to_view uid in return (Society (view, stage))
 
 let to_view uid =
   lwt created_on, origin, destination, reference, subject, content, action = $message(uid)->(created_on, origin, destination, reference, subject, content, action) in

--- a/app/view_message.eliom
+++ b/app/view_message.eliom
@@ -25,7 +25,7 @@ open Sessions
 open Ys_uid
 open Vault
 
-type interlocutor = Stage of string | Member of View_member.t | CatchAll
+type interlocutor = Stage of string | Member of View_member.t | CatchAll | Society of (View_society.t * string)
 
 type action = Pending | RoutedToStage of string
 type t =
@@ -46,8 +46,11 @@ type t =
 
 let to_interlocutor = function
   Object_message.Stage stage -> return (Stage stage)
-| Object_message.Member uid -> lwt view = View_member.to_view uid in return (Member view)
+| Object_message.Member uid ->
+  lwt view = View_member.to_view uid in return (Member view)
 | Object_message.CatchAll -> return CatchAll
+| Object_message.Society (uid, stage) ->
+  lwt view = View_society.to_view uid in return (Society (view, stage))
 
 let to_view uid =
   lwt created_on, origin, destination, reference, subject, content, action = $message(uid)->(created_on, origin, destination, reference, subject, content, action) in
@@ -79,6 +82,7 @@ open Eliom_content.Html5.D
 
 let format_interlocutor = function
     | Stage stage -> [ pcdata "Stage " ; pcdata stage ]
+    | Society (society, stage) -> [ pcdata "Society " ; pcdata society.View_society.name ; pcdata " - " ; pcdata stage ]
     | Member member -> [ pcdata "Member " ; View_member.format_message member ]
     | CatchAll -> [ pcdata "CatchAll" ]
 

--- a/app/view_playbook.eliom
+++ b/app/view_playbook.eliom
@@ -214,7 +214,14 @@ let format view =
                ])
 
            state
-        )
+        ) ;
+
+      div ~a:[ a_class [ "view-details" ]] [
+        button
+          ~a:[ a_button_type `Button ;
+               a_onclick (fun _ -> Service.goto (Service.Playbook view.uid)) ]
+          [ pcdata "View details" ]
+      ] ;
     ] ;
   ]
 

--- a/graph/object_message.ml
+++ b/graph/object_message.ml
@@ -62,7 +62,7 @@ type t = {
 
   created_on : timestamp ;
 
-  society : uid ;
+  (* society : uid ; what is this field about?? *)
 
   origin : interlocutor ;
   destination : interlocutor ;
@@ -86,7 +86,7 @@ type t = {
   (
     {
       aliases = [ `String reference ] ;
-      required = [ society ; origin ; content ; destination ; reference ] ;
+      required = [ origin ; content ; destination ; reference ] ;
       uniques = [ reference ] ;
     }
   )

--- a/graph/object_message.ml
+++ b/graph/object_message.ml
@@ -35,7 +35,7 @@ type transport =
   | NoTransport
   | Email of transport_email with bin_io, default_value(NoTransport)
 
-type interlocutor = Stage of string | Member of uid | CatchAll with bin_io
+type interlocutor = Stage of string | Member of uid | CatchAll | Society of (uid * string) with bin_io
 
 type strings = string list with bin_io, default_value([])
 

--- a/graph/object_society.ml
+++ b/graph/object_society.ml
@@ -54,6 +54,7 @@ type slip =
   } with bin_io
 
 type stack = call list with bin_io, default_value([])
+type side_stack = (int * call) list with bin_io, default_value([])
 type history = (call * call option) list with bin_io, default_value([])
 
 type int64s = int64 list with bin_io, default_value([])
@@ -80,7 +81,7 @@ type t = {
   outbox : [ `Message of slip ] edges ;
 
   stack : stack ;
-  sidecar : stack ; (* to be written by the api method, before being merged into the main stack *)
+  sidecar : side_stack ; (* to be written by the api method, before being merged into the main stack *)
   tombstones : stack ;
 
   history : history ;

--- a/library/server/ys_googlemaps.ml
+++ b/library/server/ys_googlemaps.ml
@@ -20,6 +20,8 @@
 open Lwt
 open Eliom_content.Html5.D
 
+open Ys_googlemaps_types
+
 (* server-side gmaps **********************************************************)
 
 exception InvalidResult of string
@@ -83,43 +85,6 @@ let script () =
 
 
 (* directions API for the TSP *************************************************)
-
-type status =
-    OK
-  | NOT_FOUND
-  | ZERO_RESULTS
-  | MAX_WAYPOINTS_EXCEEDED
-  | INVALID_REQUEST
-  | OVER_QUERY_LIMIT
-  | REQUEST_DENIED
-  | UNKNOWN_ERROR with yojson
-
-type duration = {
-  text : string ;
-  value : int ;
-} with yojson
-
-type step = {
-  duration : duration ;
-  html_instructions : string
-} with yojson
-
-type leg = {
-  duration : duration ;
-  steps : step list
-} with yojson
-
-type route = {
-  legs : leg list
-} with yojson
-
-type directions = {
-
-  status : string ;
-  routes : route list ;
-
-} with yojson
-
 
 let get_directions origin destination waypoints =
   let api_key = Ys_config.get_string Ys_config.google_maps_api_key in

--- a/library/shared/ys_googlemaps_types.ml
+++ b/library/shared/ys_googlemaps_types.ml
@@ -17,36 +17,36 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *)
 
-type child = {
-  name : string ;
-  age_string : string ;
-  age_in_months : int ;
+type status =
+    OK
+  | NOT_FOUND
+  | ZERO_RESULTS
+  | MAX_WAYPOINTS_EXCEEDED
+  | INVALID_REQUEST
+  | OVER_QUERY_LIMIT
+  | REQUEST_DENIED
+  | UNKNOWN_ERROR with yojson
+
+type duration = {
+  text : string ;
+  value : int ;
 } with yojson
 
-type profile = {
-  uid : int ;
-  email : string ;
-  name : string ;
-  children : child list ;
-  neighborhood : string ;
-  schedule : string ;
-  groups : string list ;
+type step = {
+  duration : duration ;
+  html_instructions : string
 } with yojson
 
-type profile_field = Name | Children | Neighborhood | Schedule with yojson
-type profile_fields = profile_field list with yojson
-
-type quote_request = {
-  reference : string ;
-  route : Ys_googlemaps_types.route ;
-  comment : string ;
+type leg = {
+  duration : duration ;
+  steps : step list
 } with yojson
 
-type quote = {
-  reference : string ;
-  number_of_seats : int ;
-  cost : float ;
-  currency : string ;
+type route = {
+  legs : leg list
 } with yojson
 
-type quotes = quote list with yojson
+type directions = {
+  status : string ;
+  routes : route list ;
+} with yojson

--- a/playbooks/children_schoolbus.ml
+++ b/playbooks/children_schoolbus.ml
@@ -32,9 +32,12 @@ let description = "this playbook organizes a preschool on wheels by proposing ac
 let version = 0
 let tags = ""
 
+(* tags ***********************************************************************)
+
+let tag_mute = "mute"
+
 (* keys ***********************************************************************)
 
-let key_original_message = "original-message"
 let key_profile = sprintf "profile-%d"
 let key_last_message = sprintf "last-message-%d"
 
@@ -93,7 +96,10 @@ let check_if_member_already_exists context message =
   lwt members = $society(context.society)->members in
   match Ys_uid.Edges.mem sender members with
     true -> return `Yes
-  | false -> return (`No message)
+  | false ->
+    (* let's add the member now *)
+    lwt _ = context.add_member ~member:sender in
+    return (`No message)
 
 let noop context () =
   return `None
@@ -106,7 +112,6 @@ let ask_supervisor_to_extract_information context message =
   lwt _ =
     context.forward_to_supervisor
       ~message
-      ~data:[ key_original_message, string_of_int message ]
       ~subject:"Your input is needed"
       ~content:[
         pcdata "Greetings," ; br () ;
@@ -139,7 +144,7 @@ let store_profile_and_ask_for_missing_elements context message =
       List.filter
         (function
           | Name -> profile.name = ""
-          | Children ->(try profile.children = [] || ((List.hd profile.children).age_string = "") with _ -> true)
+          | Children -> (try profile.children = [] || ((List.hd profile.children).age_string = "") with _ -> true)
           | Neighborhood -> profile.neighborhood = ""
           | Schedule -> profile.schedule = "")
         fields
@@ -166,31 +171,33 @@ let store_profile_and_ask_for_missing_elements context message =
     in
     return `None
 
-
 let thank_member context member =
   lwt salutations = salutations member in
-  (* we add the member at the end of the onboarding process *)
+  (* we add the member at the end of the onboarding process, although we could have done it earlier? *)
   lwt _ = context.add_member ~member in
   match_lwt context.get ~key:(key_last_message member) with
   | None ->
-    let _ =
-      context.message_member
-        ~member
-        ~subject:"Preschool on wheels"
-        ~content:[
-        salutations ; br () ;
-        br () ;
-        pcdata "Thanks for your note. We would need a little more participants to fill up the first bus, do you know people who would be interested in joining us?"
-      ]
-      () in
-    return `None
+    (match_lwt context.check_tag_member ~member ~tag:tag_mute with
+       true -> return `None
+     | false ->
+       let _ =
+         context.message_member
+           ~member
+           ~subject:"Preschool on wheels"
+           ~content:[
+             salutations ; br () ;
+             br () ;
+             pcdata "Thanks for your note. I'll follow up shortly with more details but we would need a little more participants to fill up the first bus, do you know people who would be interested in joining us?"
+           ]
+           () in
+       return `None)
   | Some message ->
     let message = int_of_string message in
     let _ =
       context.reply_to
         ~message
         ~content:[
-          pcdata "Thanks, that's great. We would need a little more participants to fill up the first bus, do you know people who would be interested in joining us?"
+          pcdata "Thanks, that's great. I'll follow up shortly with more details but we would need a little more participants to fill up the first bus, do you know people who would be interested in joining us?"
         ]
         ()
     in
@@ -350,8 +357,31 @@ let group_all_members context () =
     in
   return `None
 
-
-
+let new_member__ context member =
+  (* let's see if we have a profile *)
+  match_lwt get_profile context member with
+    Some _ -> return `None
+  | None ->
+    context.log_info "new member, asking supervisor for a hint about this member" ;
+    lwt _ = context.tag_member ~member ~tags:[ tag_mute ] in
+    lwt profile = get_or_create_profile context member in
+    let stringified = Yojson_profile.to_string profile in
+    lwt email = $member(member)->preferred_email in
+    lwt _ =
+      context.message_supervisor
+        ~subject:"Your input is needed"
+        ~content:[
+          pcdata "Greetings," ; br () ;
+          br () ;
+          pcdata "You just added " ; pcdata email ; pcdata " to the group, do you want to prefill the profile?" ; br () ;
+          br () ;
+          pcdata "Could you fill up the Json below? (and return only the json)" ; br () ;
+          br () ;
+          pcdata stringified ; br () ;
+        ]
+        ()
+    in
+    return `None
 
 
 (* the playbook ***************************************************************)
@@ -359,7 +389,6 @@ let group_all_members context () =
 PLAYBOOK
 
    #import core_join_request
-
 
 (* onboarding process *)
 
@@ -372,6 +401,7 @@ PLAYBOOK
         store_profile_and_ask_for_missing_elements ~> `ThankMember of int ~> thank_member
         store_profile_and_ask_for_missing_elements ~> `AskMemberForMissingFields of (int * profile_fields) ~> ask_member_for_missing_fields<forward> ~> `Message of email ~> store_reply ~> `Message of email ~> ask_supervisor_to_extract_information
 
+new_member__<forward> ~> `Message of email ~> store_profile_and_ask_for_missing_elements
 
 (* organizing a trip *)
 

--- a/playbooks/children_schoolbus.ml
+++ b/playbooks/children_schoolbus.ml
@@ -300,6 +300,7 @@ let group_all_members context () =
   let profiles = Ys_list.take 22 profiles in
   try_lwt
     let open Ys_googlemaps in
+    let open Ys_googlemaps_types in
     (* bit of hard coding here .. *)
     lwt directions =
       get_directions

--- a/playbooks/children_schoolbus_planner.ml
+++ b/playbooks/children_schoolbus_planner.ml
@@ -1,0 +1,97 @@
+(*
+ * children_schoolbus_planner
+ *
+ * this playbook plans the trips
+ *
+ *
+ * william@accret.io
+ *
+ *)
+
+
+open Lwt
+
+open Printf
+open CalendarLib
+
+open Api
+
+open Eliom_content.Html5
+open Eliom_content.Html5.D
+
+open Message_parsers
+open Toolbox
+
+open Ys_uid
+open Ys_googlemaps_types
+
+open Children_schoolbus_types
+
+let author = "william@accret.io"
+let name = "Children schoolbus planner"
+let description = "this playbook plans the trips"
+let version = 0
+let tags = ""
+
+(* this playbook expects to be connected to children_schoolbus_transportation
+    and children_schoolbus_groups *)
+
+(* some keys ******************************************************************)
+
+(* some tags ******************************************************************)
+
+(* the stages *****************************************************************)
+
+(* the playbook ***************************************************************)
+
+let validate_transporation context () =
+  context.log_info "validate tranportation" ;
+  match_lwt context.search_societies ~query:"tran*" () with
+  | [] -> return `NoTransporationProvider
+  | _ as providers ->
+    let quote_request =
+      {
+        reference = "testquote" ;
+        route = { legs = [] } ;
+        comment = "this is a testing quote request"
+      }
+    in
+    lwt _ =
+      Lwt_list.iter_s
+        (fun society ->
+           context.log_info "messaging society %d" society ;
+           lwt _ =
+             context.message_society
+               ~society
+               ~stage:"desk" (* how am I supposed to know that? *)
+               ~subject:"quote request"
+               ~content:(Yojson_quote_request.to_string quote_request)
+               ()
+           in
+           return_unit)
+        providers
+    in
+    return `None
+
+let no_transportation_provider context () =
+  lwt _ =
+    context.message_supervisor
+      ~subject:"No transporation provider"
+      ~content:[
+        pcdata "Greetings," ; br () ;
+        br () ;
+        pcdata "This society isn't connected to a transporation provider"
+      ]
+      ()
+  in
+  return `None
+
+PLAYBOOK
+
+#import core_remind
+
+*validate_transporation ~> `NoTransporationProvider ~> no_transportation_provider
+
+
+PROPERTIES
+  - "Your duties", "None"

--- a/playbooks/children_schoolbus_transportation.ml
+++ b/playbooks/children_schoolbus_transportation.ml
@@ -33,13 +33,20 @@ let description = "this playbook figures out the transporation solution"
 let version = 0
 let tags = ""
 
+(* some keys ******************************************************************)
+
+let key_original_message = "original-message"
+
 (* the stages *****************************************************************)
 
-let desk context message =
+let desk context () =
+  return `None
+
+let extract_quote_request context message =
   lwt content = context.get_message_content ~message in
   try_lwt
     let quote_request = Yojson_quote_request.from_string content in
-    return (`ComputeQuote quote_request)
+    return (`ComputeQuote (message, quote_request))
   with exn ->
     context.log_error ~exn "couldn't respond to the quote request" ;
     lwt _ =
@@ -57,7 +64,7 @@ let desk context message =
     in
     return `None
 
-let compute_quote context (quote_request: quote_request) =
+let compute_quote context ((message, quote_request): (int * quote_request)) =
   context.log_info "got quote request: %s %s" quote_request.reference quote_request.comment ;
   let empty_quote =
     {
@@ -70,6 +77,7 @@ let compute_quote context (quote_request: quote_request) =
   lwt _ =
     context.message_supervisor
       ~subject:"New quote request"
+      ~data:[ key_original_message, string_of_int message ]
       ~content:[
         pcdata "Greetings," ; br () ;
         br () ;
@@ -89,13 +97,39 @@ let compute_quote context (quote_request: quote_request) =
   return `None
 
 let extract_quote_and_send_it_back context message =
-  return `None
+  match_lwt context.get_message_data ~message ~key:key_original_message with
+    None ->
+    lwt _ =
+      context.reply_to
+        ~message
+        ~content:[ pcdata "Couldn't find the original message" ]
+        ()
+    in
+    return `None
+  | Some message ->
+    let message = int_of_string message in
+    let quote_reply = Error "couldn't compute quote" in
+    let empty_quote =
+      {
+        reference = "coucou" ;
+        number_of_seats = 0  ;
+        cost = 0.0 ;
+        currency = "USD"
+      }
+    in
+    lwt _ =
+      context.reply_to
+        ~message
+        ~content:[ Unsafe.data (Yojson_quote_reply.to_string quote_reply) ]
+        ()
+    in
+    return `None
 
 (* the playbook ***************************************************************)
 
 PLAYBOOK
 
--desk ~> `ComputeQuote of quote_request ~> compute_quote ~> `Message of email ~> extract_quote_and_send_it_back
+*desk<forward> ~> `Message of email ~> extract_quote_request ~> `ComputeQuote of (int * quote_request) ~> compute_quote ~> `Message of email ~> extract_quote_and_send_it_back
 
 PROPERTIES
   - "Your duties", "None"

--- a/playbooks/children_schoolbus_transportation.ml
+++ b/playbooks/children_schoolbus_transportation.ml
@@ -58,7 +58,7 @@ let desk context message =
     return `None
 
 let compute_quote context (quote_request: quote_request) =
-  context.log_info "got quote request" ;
+  context.log_info "got quote request: %s %s" quote_request.reference quote_request.comment ;
   let empty_quote =
     {
       reference = quote_request.reference ;

--- a/playbooks/children_schoolbus_transportation.ml
+++ b/playbooks/children_schoolbus_transportation.ml
@@ -1,0 +1,101 @@
+(*
+ * children_schoolbus_transporation
+ *
+ * this playbook figures out the transportation solution. it currently manually
+ * asks for a quote, but later it could figure out the bus availability, etc
+ *
+ *
+ * william@accret.io
+ *
+ *)
+
+
+open Lwt
+
+open Printf
+open CalendarLib
+
+open Api
+
+open Eliom_content.Html5
+open Eliom_content.Html5.D
+
+open Message_parsers
+open Toolbox
+
+open Ys_uid
+
+open Children_schoolbus_types
+
+let author = "william@accret.io"
+let name = "Children schoolbus transportation"
+let description = "this playbook figures out the transporation solution"
+let version = 0
+let tags = ""
+
+(* the stages *****************************************************************)
+
+let desk context message =
+  lwt content = context.get_message_content ~message in
+  try_lwt
+    let quote_request = Yojson_quote_request.from_string content in
+    return (`ComputeQuote quote_request)
+  with exn ->
+    context.log_error ~exn "couldn't respond to the quote request" ;
+    lwt _ =
+      context.forward_to_supervisor
+        ~message
+        ~subject:"Couldn't extract quote request"
+        ~content:[]
+        ()
+    in
+    lwt _ =
+      context.reply_to
+        ~message
+        ~content:[ pcdata "ERROR" ]
+        ()
+    in
+    return `None
+
+let compute_quote context (quote_request: quote_request) =
+  context.log_info "got quote request" ;
+  let empty_quote =
+    {
+      reference = quote_request.reference ;
+      number_of_seats = 0  ;
+      cost = 0.0 ;
+      currency = "USD"
+    }
+  in
+  lwt _ =
+    context.message_supervisor
+      ~subject:"New quote request"
+      ~content:[
+        pcdata "Greetings," ; br () ;
+        br () ;
+        pcdata "Here is a new quote request:" ; br () ;
+        br () ;
+        pcdata (Yojson_quote_request.to_string quote_request) ;
+        br () ;
+        br () ;
+        pcdata "Could you fill the JSON below with your response?" ; br () ;
+        br () ;
+        pcdata (Yojson_quote.to_string empty_quote) ; br () ;
+        br () ;
+        pcdata "Thanks!"
+      ]
+      ()
+  in
+  return `None
+
+let extract_quote_and_send_it_back context message =
+  return `None
+
+(* the playbook ***************************************************************)
+
+PLAYBOOK
+
+-desk ~> `ComputeQuote of quote_request ~> compute_quote ~> `Message of email ~> extract_quote_and_send_it_back
+
+PROPERTIES
+  - "Your duties", "None"

--- a/playbooks/children_schoolbus_types.ml
+++ b/playbooks/children_schoolbus_types.ml
@@ -50,3 +50,5 @@ type quote = {
 } with yojson
 
 type quotes = quote list with yojson
+
+type quote_reply = Error of string | Quotes of quote list with yojson

--- a/playbooks/core_remind.ml
+++ b/playbooks/core_remind.ml
@@ -32,7 +32,7 @@ let remind__ context message =
   lwt _ =
     context.reply_to
       ~message
-      ~original_stage:true
+      ~preserve_origin:true
       ~content:[ pcdata "Have you seen my previous message? Thanks!" ; br () ]
       ()
   in

--- a/style/sass/_view_playbook.scss
+++ b/style/sass/_view_playbook.scss
@@ -44,5 +44,6 @@
         .done {
             text-align: center ;
         }
+
     }
 }


### PR DESCRIPTION
- extended api with a message_society function
- full reimplementation of the context that provides the Api.T functions
- tested on the children_schoolbus_\* playbooks, seem to work seamlessly. 

there is still some junk variants in some types, mostly Object_message.Stage. It is now replaced by Object_message.Society (_, stage); I'll eventually remove it. 
